### PR TITLE
Fix broken installation due to missing dependency files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include delft3d/config_d_hydro.xml

--- a/setup.py
+++ b/setup.py
@@ -3,4 +3,6 @@
 import setuptools
 
 if __name__ == "__main__":
-    setuptools.setup()
+    setuptools.setup(
+        include_package_data=True,
+    )


### PR DESCRIPTION
Certain files are excluded from installations by default. As the project depends on a `config_d_hydro.xml` file, it is important to make sure this is included.

There are [multiple ways to do this](https://packaging.python.org/en/latest/guides/using-manifest-in/), one of which is specifying a `MANIFEST.ini` file.

This PR fixes this issue.